### PR TITLE
Adding newline before titles

### DIFF
--- a/osa_differ/osa_differ.py
+++ b/osa_differ/osa_differ.py
@@ -417,7 +417,7 @@ def run_osa_differ():
     role_yaml_latest = get_roles(osa_repo_dir, osa_new_commit)
 
     # Generate the role report.
-    report_rst += ("OpenStack-Ansible Roles\n"
+    report_rst += ("\nOpenStack-Ansible Roles\n"
                    "-----------------------")
     report_rst += make_report(storage_directory,
                               role_yaml,
@@ -430,7 +430,7 @@ def run_osa_differ():
                                        osa_new_commit)
 
     # Generate the project report.
-    report_rst += ("OpenStack Projects\n"
+    report_rst += ("\nOpenStack Projects\n"
                    "------------------")
     report_rst += make_report(storage_directory,
                               project_yaml,


### PR DESCRIPTION
This is required for the RST to be properly converted
to Markdown when using pandoc