### PR TITLE
Fetch additional RefSpecs

### DIFF
--- a/osa_differ/osa_differ.py
+++ b/osa_differ/osa_differ.py
@@ -359,7 +359,11 @@ def repo_pull(repo_dir, repo_url, fetch=False):
 
     # Only get the latest updates if requested.
     if fetch:
-        repo.git.fetch([repo_url, "+refs/heads/*:refs/remotes/origin/*"])
+        repo.git.fetch(["-u", "-v", "-f",
+                        repo_url,
+                        "+refs/heads/*:refs/remotes/origin/*",
+                        "+refs/heads/*:refs/heads/*",
+                        "+refs/tags/*:refs/tags/*"])
         repo.git.reset(["--hard", "FETCH_HEAD"])
     return repo
 


### PR DESCRIPTION
This commit adds tags to the refs to be fetched, it also double fetches
heads into origin and local branches. This means users don't have
to specify origin/branch_name but it will still work if they do.

This also fixes a problem where git refuses to overwrite HEAD when fetching, by adding flags to disable its morality. 