### PR TITLE
RE-622 Fix GitHub URLs ending with .git in report

### DIFF
--- a/osa_differ/osa_differ.py
+++ b/osa_differ/osa_differ.py
@@ -147,7 +147,7 @@ def get_commits(repo_dir, old_commit, new_commit, hide_merges=True):
 def get_commit_url(repo_url):
     """Determine URL to view commits for repo."""
     if "github.com" in repo_url:
-        return repo_url
+        return repo_url[:-4] if repo_url.endswith(".git") else repo_url
     if "git.openstack.org" in repo_url:
         uri = '/'.join(repo_url.split('/')[-2:])
         return "https://github.com/{0}".format(uri)

--- a/tests/test_osa_differ.py
+++ b/tests/test_osa_differ.py
@@ -45,10 +45,16 @@ class TestOSADiffer(object):
         assert isinstance(parser, argparse.ArgumentParser)
 
     def test_commit_url_github(self):
-        """Verify that GitHub URLs are unaltered."""
+        """Verify that GitHub URLs without ".git" are unaltered."""
         repo_url = "https://github.com/openstack/openstack-ansible"
         result = osa_differ.get_commit_url(repo_url)
         assert result == repo_url
+
+    def test_commit_url_github_ending_with_dotgit(self):
+        """Verify that ".git" is stripped from GitHub URLs."""
+        repo_url = "https://github.com/openstack/openstack-ansible.git"
+        result = osa_differ.get_commit_url(repo_url)
+        assert result == repo_url[:-4]
 
     def test_commit_url_openstack(self):
         """Verify that OpenStack URLs are fixed."""


### PR DESCRIPTION
This change strips `".git"` from GitHub URLs used in the report.

The report produced by osa-differ/rpc-differ includes links to the
individual commits on GitHub. If a URL supplied on the command-line or
defined in an Ansible role file ended with `".git"`, the links generated
for the report would fail with a 404 without this change.

Without this change:

Valid commit links only generated from a URL not ending in `".git"`:
https://github.com/major/osa_differ/commit/SHA

Invalid commit links generated from a URL ending in `".git"`:
https://github.com/major/osa_differ.git/commit/SHA