### PR TITLE
Make sure a repo cloned by osa_differ is properly prepared

### DIFF
--- a/osa_differ/osa_differ.py
+++ b/osa_differ/osa_differ.py
@@ -371,12 +371,14 @@ def repo_pull(repo_dir, repo_url, fetch=False):
 def update_repo(repo_dir, repo_url, fetch=False):
     """Clone the repo if it doesn't exist already, otherwise update it."""
     repo_exists = os.path.exists(repo_dir)
-    if repo_exists:
-        log.info("Fetching repo {} (fetch: {})".format(repo_url, fetch))
-        repo = repo_pull(repo_dir, repo_url, fetch)
-    else:
+    if not repo_exists:
         log.info("Cloning repo {}".format(repo_url))
         repo = repo_clone(repo_dir, repo_url)
+
+    # Make sure the repo is properly prepared
+    # and has all the refs required
+    log.info("Fetching repo {} (fetch: {})".format(repo_url, fetch))
+    repo = repo_pull(repo_dir, repo_url, fetch)
 
     return repo
 

--- a/osa_differ/osa_differ.py
+++ b/osa_differ/osa_differ.py
@@ -232,7 +232,7 @@ def make_report(storage_directory, old_pins, new_pins, do_update=False):
         # added projects and roles.
         try:
             commit_sha_old = next(x[2] for x in old_pins if x[0] == repo_name)
-        except:
+        except Exception:
             continue
 
         # Loop through the commits and render our template.
@@ -390,7 +390,7 @@ def validate_commits(repo_dir, commits):
     for commit in commits:
         try:
             commit = repo.commit(commit)
-        except:
+        except Exception:
             msg = ("Commit {commit} could not be found in repo {repo}. "
                    "You may need to pass --update to fetch the latest "
                    "updates to the git repositories stored on "
@@ -405,14 +405,14 @@ def validate_commit_range(repo_dir, old_commit, new_commit):
     # Are there any commits between the two commits that were provided?
     try:
         commits = get_commits(repo_dir, old_commit, new_commit)
-    except:
+    except Exception:
         commits = []
     if len(commits) == 0:
         # The user might have gotten their commits out of order. Let's flip
         # the order of the commits and try again.
         try:
             commits = get_commits(repo_dir, new_commit, old_commit)
-        except:
+        except Exception:
             commits = []
         if len(commits) == 0:
             # Okay, so there really are no commits between the two commits


### PR DESCRIPTION
Currently if a repo does not exist, it gets cloned. If the
notes need to be generated from a branch other than master,
then osa_differ cannot find the ref for the commit.
When re-running osa_differ again, the repo is updated to
include all the refs, and therefore works as expected.

This patch ensures that regardless of whether osa_differ
does the clone, the repo is always updated afterwards to
get all the refs. This makes it work on the first time,
and always.