### PR TITLE
First validate that role repositories exist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name='osa_differ',
-    version='0.3.10',
+    version='0.3.11',
     author='Major Hayden',
     author_email='major@mhtx.net',
     description="Find changes between OpenStack-Ansible versions",

--- a/tests/test_osa_differ.py
+++ b/tests/test_osa_differ.py
@@ -554,6 +554,16 @@ novncproxy_git_project_group: nova_console
         assert result.active_branch.name == 'master'
         assert not result.is_dirty()
 
+    def test_valid_repo_url(self, tmpdir):
+        """Ensure that valid git URL passes validation."""
+        assert osa_differ.validate_repo(
+            "https://github.com/rcbops/rpc-openstack")
+
+    def test_invalid_repo_url(self, tmpdir):
+        """Ensure that invalid git URL fails validation."""
+        assert not osa_differ.validate_repo(
+            "there_is_no_spoon")
+
     def test_get_release_notes(self, tmpdir):
         """Ensure getting release notes works."""
         p = tmpdir.mkdir('releasenotes')


### PR DESCRIPTION
Recently ceph-ansible deleted roles from github,
causing osa-differ to fail when trying to check
for changes between two refs.

To cater to this situation, we add a check to see
whether a role repository exists. If not, it does
not include it in the list of roles to compare.

JIRA: RI-641